### PR TITLE
Replace mirror with ripple

### DIFF
--- a/subroutines/util/display_image_pair.m
+++ b/subroutines/util/display_image_pair.m
@@ -23,8 +23,8 @@ if fill
     pad_width = 25; % constant pad width because it does not seem worth specifying
     xx0 = xx; % coordinates get overwritten, use the originals
     yy0 = yy;
-    [xx, yy, ini] = piv_fill(xx0, yy0, ini, ini_roi, 0, 0);
-    [~, ~, fin] = piv_fill(xx0, yy0, fin, fin_roi, 0, 0);
+    [xx, yy, ini] = piv_fill(xx0, yy0, ini, ini_roi, pad_width, pad_width);
+    [~, ~, fin] = piv_fill(xx0, yy0, fin, fin_roi, pad_width, pad_width);
 
 else
     % apply mask


### PR DESCRIPTION
In an attempt to correct the high strain at the wedge base, I now mirror only a short depth into the wedge. The idea was to limit mirroring regions that are significantly strained relative to the boundary. This neatly removes all artifacts from the upper surface, but the bottom is still a mess. I conclude that this is worth including, but that I did not understand the real problem at the base.